### PR TITLE
Custom endpoint path support

### DIFF
--- a/jsonapi_requests/orm/api_model.py
+++ b/jsonapi_requests/orm/api_model.py
@@ -12,13 +12,11 @@ class JsonApiObjectStub:
 
 class ApiModelMetaclass(type):
     def __init__(cls, name, bases, attrs, **kwargs):
-        super().__init__(name, bases, attrs, **kwargs)
+        super().__init__(name, bases, attrs)
         options = OptionsFactory(cls, attrs).get()
         cls._options = options
         if options.api and options.type:
             options.api.type_registry.register(cls)
-            if 'list_endpoint' not in kwargs:
-                cls.list_endpoint = cls._options.api.endpoint('{}'.format(cls._options.type))
 
 
 class OptionsFactory:
@@ -27,7 +25,11 @@ class OptionsFactory:
         self.klass_attrs = klass_attrs
 
     def get(self):
-        return Options(type=self.type, api=self.api, fields=self.fields)
+        return Options(type=self.type, api=self.api, fields=self.fields, path=self.path)
+
+    @property
+    def path(self):
+        return self.get_setting('path')
 
     @property
     def type(self):
@@ -58,10 +60,11 @@ class OptionsFactory:
 
 
 class Options:
-    def __init__(self, type, api, fields):
+    def __init__(self, type, api, fields, path):
         self.type = type
         self.api = api
         self.fields = fields
+        self.path = path
 
 
 class ApiModel(metaclass=ApiModelMetaclass):
@@ -70,13 +73,16 @@ class ApiModel(metaclass=ApiModelMetaclass):
         self.relationship_cache = {}
 
     @classmethod
+    def endpoint_path(cls):
+        return cls._options.path or cls._options.type
+
+    @classmethod
     def from_id(cls, id):
         return cls(raw_object=JsonApiObjectStub(id))
 
-
     @classmethod
     def get_list(cls):
-        response = cls.list_endpoint.get()
+        response = cls._options.api.endpoint(cls.endpoint_path()).get()
         return cls.from_response_content(response.content)
 
     @classmethod
@@ -95,7 +101,6 @@ class ApiModel(metaclass=ApiModelMetaclass):
             repository.add(result)
         repository.update_from_api_response(jsonapi_response)
         return result
-
 
     @property
     def type(self):
@@ -145,7 +150,7 @@ class ApiModel(metaclass=ApiModelMetaclass):
             self.update()
 
     def create(self):
-        api_response = self.list_endpoint.post(object=self.raw_object)
+        api_response = self._options.api.endpoint(self.endpoint_path()).post(object=self.raw_object)
         if api_response.status_code == 201:
             self.raw_object = api_response.content.data
 
@@ -161,6 +166,6 @@ class ApiModel(metaclass=ApiModelMetaclass):
 
     @property
     def endpoint(self):
-        return self._options.api.endpoint('{}/{}'.format(self._options.type, self.id))
+        return self._options.api.endpoint('{}/{}'.format(self.endpoint_path(), self.id))
 
-    _options = Options(None, None, {})
+    _options = Options(None, None, {}, None)

--- a/jsonapi_requests/orm/api_model.py
+++ b/jsonapi_requests/orm/api_model.py
@@ -11,7 +11,7 @@ class JsonApiObjectStub:
 
 
 class ApiModelMetaclass(type):
-    def __init__(cls, name, bases, attrs, **kwargs):
+    def __init__(cls, name, bases, attrs):
         super().__init__(name, bases, attrs)
         options = OptionsFactory(cls, attrs).get()
         cls._options = options

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -138,7 +138,7 @@ class TestApiModel:
 
         class Design(orm.ApiModel):
             class Meta:
-                type = 'design'
+                type = 'designs'
                 api = orm_api
 
             name = orm.AttributeField('name')
@@ -148,9 +148,8 @@ class TestApiModel:
         assert design.id is None
         design.save()
         assert design.id == '1'
-        mock_api.endpoint.assert_called_with('design')
         mock_api.endpoint.return_value.post.assert_called_with(
-            object=data.JsonApiObject.from_data({'type': 'design', 'attributes': {'name': 'doctor_x'}})
+            object=data.JsonApiObject.from_data({'type': 'designs', 'attributes': {'name': 'doctor_x'}})
         )
 
     def test_saving_new_custom_path(self):


### PR DESCRIPTION
This is primarily to support APIs where the type names are singular
but the routes are plural.

The path can be provided by setting the `path` attribute on the
metaclass for the model. If not set, it will default to the type name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/jsonapi-requests/32)
<!-- Reviewable:end -->
