### PR TITLE
Allow passing arguments through to get_list

### DIFF
--- a/jsonapi_requests/orm/api_model.py
+++ b/jsonapi_requests/orm/api_model.py
@@ -81,8 +81,8 @@ class ApiModel(metaclass=ApiModelMetaclass):
         return cls(raw_object=JsonApiObjectStub(id))
 
     @classmethod
-    def get_list(cls):
-        response = cls._options.api.endpoint(cls.endpoint_path()).get()
+    def get_list(cls, **kwargs):
+        response = cls._options.api.endpoint(cls.endpoint_path()).get(**kwargs)
         return cls.from_response_content(response.content)
 
     @classmethod

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -405,3 +405,20 @@ class TestApiModel:
         assert mock_api.endpoint.return_value.delete.call_count == 1
         assert model.id == '123'
         assert model.name == 'alice'
+
+    def test_getting_list_with_params(self):
+        mock_api = mock.MagicMock()
+        mock_api.endpoint.return_value.get.return_value.content.data = [mock.Mock(
+            type='test', id='123', attributes={'name': 'alice'})]
+        orm_api = orm.OrmApi(mock_api)
+
+        class Test(orm.ApiModel):
+            class Meta:
+                api = orm_api
+                type = 'test'
+            name = orm.AttributeField(source='name')
+
+        result = Test.get_list(headers={'X-Test': 'test'}, params={'sort': 'name'})
+        mock_api.endpoint.assert_called_with('test')
+        mock_api.endpoint.return_value.get.assert_called_with(headers={'X-Test': 'test'}, params={'sort': 'name'})
+        assert result[0].name == 'alice'


### PR DESCRIPTION
When using an `Endpoint` directly, it's possible to pass through
any `**kwargs` directly to requests.

The `ApiModel::get_list` did not allow any arguments, but this is
useful if you want to pass query parameters (e.g. sort, filter) when
fetching a collection.

This fixes socialwifi/jsonapi-requests#25.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/jsonapi-requests/34)
<!-- Reviewable:end -->
