### PR TITLE
[obsolete] Custom field type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,43 @@ Then we can run:
     In [9]: car.driver.married_to.married_to.name
     Out[9]: 'Kowalski'
 
+### Custom Field Types
+
+It's possible to use custom types for an `AttributeField` by subclassing `jsonapi_requests.orm.converters.BaseConverter`.
+Example:
+
+    from enum import Enum
+    from uuid import UUID
+
+    from jsonapi_requets import orm
+    from jsonapi_requests.orm.converters import BaseConverter, EnumConverter
+    
+    class Color(Enum):
+        RED = 'red'
+        BLUE = 'blue'
+       
+    class UuidConverter(BaseConverter):
+        def encode(self, value):
+            # take a UUID object and make it JSON serializable
+            return str(value)
+        
+        def decode(self, raw_value):
+            # take the JSON value (a string in this case) and turn it into a UUID
+            return UUID(raw_value)
+    
+    class Car(jsonapi_requests.orm.ApiModel):
+        class Meta:
+            type = 'car'
+           
+        color = jsonapi_requests.orm.AttributeField('color', converter=EnumConverter(Color)
+        guid = jsonapi_requests.orm.AttributeField('guid', converter=UuidConverter())
+    
+    car = Car()
+    car.color = Color.RED
+    car.guid = UUID('4cbecc77-fc43-4d29-8915-222d87029ec3')
+    car.save()
+
+
 ## Authorization HTTP header forwarding in Flask application
 
 When using jsonapi\_requests with Flask, we can set `jsonapi_requests.auth.FlaskForwardAuth()` as `AUTH` configuration option to copy authorization header from current request context.

--- a/jsonapi_requests/orm/api_model.py
+++ b/jsonapi_requests/orm/api_model.py
@@ -69,8 +69,9 @@ class Options:
 
 class ApiModel(metaclass=ApiModelMetaclass):
     def __init__(self, raw_object=None):
-        self.raw_object = raw_object or data.JsonApiObject(type=self._options.type)
+        self._raw_object = raw_object or data.JsonApiObject(type=self._options.type)
         self.relationship_cache = {}
+        self.converter_cache = {}
 
     @classmethod
     def endpoint_path(cls):
@@ -120,6 +121,15 @@ class ApiModel(metaclass=ApiModelMetaclass):
     @id.setter
     def id(self, new_id):
         self.raw_object.id = new_id
+
+    @property
+    def raw_object(self):
+        return self._raw_object
+
+    @raw_object.setter
+    def raw_object(self, value):
+        self.converter_cache.clear()
+        self._raw_object = value
 
     def __getattr__(self, item):
         try:

--- a/jsonapi_requests/orm/converters.py
+++ b/jsonapi_requests/orm/converters.py
@@ -1,0 +1,29 @@
+import abc
+
+
+class BaseFieldConverter(abc.ABC):
+    @abc.abstractmethod
+    def decode(self, json_value):
+        return json_value
+
+    @abc.abstractmethod
+    def encode(self, value):
+        return value
+
+
+class EnumConverter(BaseFieldConverter):
+    def __init__(self, enum_cls, encode_as_name=False):
+        self.enum_cls = enum_cls
+        self.encode_as_name = encode_as_name
+
+    def decode(self, json_value):
+        if self.encode_as_name:
+            return self.enum_cls[json_value]
+
+        return self.enum_cls(json_value)
+
+    def encode(self, value):
+        if self.encode_as_name:
+            return value.name
+
+        return value.value

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,97 @@
+import enum
+
+from unittest import mock
+
+from jsonapi_requests import data
+from jsonapi_requests import orm
+from jsonapi_requests.orm import converters
+
+
+class TestFieldConverters:
+    def test_enum_converter_value(self):
+        class Test(enum.Enum):
+            valueA = 0
+            valueB = 1
+            valueC = 2
+
+        converter = converters.EnumConverter(Test)
+        assert converter.encode(Test.valueA) == 0
+        assert converter.decode(2) is Test.valueC
+
+    def test_enum_converter_name(self):
+        class Test(enum.Enum):
+            valueA = 0
+            valueB = 1
+            valueC = 2
+
+        converter = converters.EnumConverter(Test, encode_as_name=True)
+        assert converter.encode(Test.valueA) == 'valueA'
+        assert converter.decode('valueC') is Test.valueC
+
+    def test_custom_field_converter(self):
+        mock_api = mock.MagicMock()
+        mock_api.endpoint.return_value.post.return_value.status_code = 201
+        mock_api.endpoint.return_value.post.return_value.content.data = data.JsonApiObject(
+            type='test',
+            id='123',
+            attributes={'name': 'alice', 'extra': '0x1000'}
+        )
+        orm_api = orm.OrmApi(mock_api)
+
+        class HexConverter(converters.BaseFieldConverter):
+            def decode(self, json_value):
+                return int(json_value, 16)
+
+            def encode(self, value):
+                return hex(value)
+
+        converter = HexConverter()
+        # NOTE: assert_has_calls([]) used in place of assert_not_called() for py3.4 compatibility in this test
+        decode_spy = mock.patch.object(converter, 'decode', wraps=converter.decode).start()
+        encode_spy = mock.patch.object(converter, 'encode', wraps=converter.encode).start()
+
+        class Test(orm.ApiModel):
+            class Meta:
+                api = orm_api
+                type = 'test'
+            name = orm.AttributeField(source='name')
+            extra = orm.AttributeField(source='extra', converter=converter)
+
+        test = Test()
+        test.name = 'alice'
+        test.extra = 1024
+        assert test.extra == 1024
+
+        # verify that we can successfully change the value and re-read it
+        test.extra = 2048
+        assert test.extra == 2048
+
+        # nothing should have been decoded at this point -- the reads (for assert) should have been cached
+        decode_spy.assert_has_calls([])
+        # should have done an encode for each set
+        encode_spy.assert_has_calls([mock.call(1024), mock.call(2048)], any_order=False)
+        encode_spy.reset_mock()
+
+        test.save()
+
+        mock_api.endpoint.return_value.post.assert_called_with(
+            object=data.JsonApiObject.from_data(
+                {
+                    'type': 'test',
+                    'attributes': {'name': 'alice', 'extra': '0x800'}
+                }
+            )
+        )
+
+        # no further encoding/decoding should have happened
+        decode_spy.assert_has_calls([])
+        decode_spy.assert_has_calls([])
+
+        # verify that the new value that the API returned was set and decoded properly
+        assert test.extra == 4096
+        decode_spy.assert_called_once_with('0x1000')
+        decode_spy.reset_mock()
+
+        # read the property again but check that we didn't re-decode it
+        assert test.extra == 4096
+        decode_spy.assert_has_calls([])


### PR DESCRIPTION
Allow passing in a type converter for an `AttributeField` that will
handle serialization/deserialization. This is useful for things like
enums, UUIDs, timestamps, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/jsonapi-requests/35)
<!-- Reviewable:end -->
