### PR TITLE
Add ability works with links in Relation ship.

### DIFF
--- a/jsonapi_requests/orm/fields.py
+++ b/jsonapi_requests/orm/fields.py
@@ -124,7 +124,14 @@ class InstanceToOneRelation(BaseInstanceRelation):
         except KeyError:
             raise ObjectKeyError
         else:
-            data = relationship.data
+            data = None
+            if (hasattr(relationship, 'data') and relationship.data.as_data() != {}) or relationship.as_data() == {}:
+                data = relationship.data
+            elif hasattr(relationship, 'links') and relationship.links != {}:
+                res = self.instance._options.api.endpoint(path=relationship.links.as_data()['self'])
+                relationship_data = res.get()
+                data = relationship_data.data
+
             if data.type is None or data.id is None:
                 raise ObjectKeyError
             else:
@@ -187,3 +194,4 @@ class InstanceCache:
 
     def get_cached(self):
         return self.instance.relationship_cache[self.source]
+

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -3,7 +3,7 @@ from unittest import mock
 from jsonapi_requests import data
 from jsonapi_requests import request_factory
 from jsonapi_requests import orm
-
+import inspect
 
 
 class TestApiModel:
@@ -109,18 +109,17 @@ class TestApiModel:
 
 
     def test_from_response_with_relationship_with_links_only(self):
+        mock_api = mock.MagicMock()
+        mock_api.endpoint().get().data =  data.ResourceIdentifier(type='test', id='159')
         response_content = data.JsonApiResponse(
             data=data.JsonApiObject(id='1', type='test', relationships={
-                'other': data.Relationship(data=data.ResourceIdentifier(id=None, type=None),
-                                           links=data.Dictionary(self='http://example.org/api/rest/admin/gateway-groups/14/relationships/vendor',
-                                                                 related='http://example.org/api/rest/admin/gateway-groups/14/vendor'
+                'other': data.Relationship(links=data.Dictionary(self='http://example.org/api/rest/test/1/relationships/vendor',
+                                                                 related='http://example.org/api/rest/test/1/vendor'
                                                                 )
-#                                           links={'self': 'http://example.org/api/rest/admin/gateway-groups/14/relationships/vendor',
-#                                                 'related': 'http://example.org/api/rest/admin/gateway-groups/14/vendor'}
                                           )
             })
         )
-        orm_api = orm.OrmApi(mock.MagicMock())
+        orm_api = orm.OrmApi(mock_api)
 
         class Test(orm.ApiModel):
             class Meta:
@@ -128,10 +127,9 @@ class TestApiModel:
                 type = 'test'
             other = orm.RelationField(source='other')
             name = orm.AttributeField(source='name')
-
         test = Test.from_response_content(response_content)
-        #print(type(test.other))
-        assert test.other is None
+        assert test.other.type is 'test'
+        assert test.other.id is '159'
 
 
     def test_issue_19_attributes_are_readable_with_multiple_relations(self):

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -5,6 +5,7 @@ from jsonapi_requests import request_factory
 from jsonapi_requests import orm
 
 
+
 class TestApiModel:
     def test_empty_declaration(self):
         class Test(orm.ApiModel):
@@ -105,6 +106,33 @@ class TestApiModel:
 
         test = Test.from_response_content(response_content)
         assert test.other is None
+
+
+    def test_from_response_with_relationship_with_links_only(self):
+        response_content = data.JsonApiResponse(
+            data=data.JsonApiObject(id='1', type='test', relationships={
+                'other': data.Relationship(data=data.ResourceIdentifier(id=None, type=None),
+                                           links=data.Dictionary(self='http://example.org/api/rest/admin/gateway-groups/14/relationships/vendor',
+                                                                 related='http://example.org/api/rest/admin/gateway-groups/14/vendor'
+                                                                )
+#                                           links={'self': 'http://example.org/api/rest/admin/gateway-groups/14/relationships/vendor',
+#                                                 'related': 'http://example.org/api/rest/admin/gateway-groups/14/vendor'}
+                                          )
+            })
+        )
+        orm_api = orm.OrmApi(mock.MagicMock())
+
+        class Test(orm.ApiModel):
+            class Meta:
+                api = orm_api
+                type = 'test'
+            other = orm.RelationField(source='other')
+            name = orm.AttributeField(source='name')
+
+        test = Test.from_response_content(response_content)
+        #print(type(test.other))
+        assert test.other is None
+
 
     def test_issue_19_attributes_are_readable_with_multiple_relations(self):
         response_content = data.JsonApiResponse(


### PR DESCRIPTION
When sever return JSON object with only 'links object' without 'data: resource linkage'. This patch add ability to retrieve data from links object. Relay to https://github.com/socialwifi/jsonapi-requests/issues/40