### PR TITLE
`__all__` should be a list of strings

### DIFF
--- a/jsonapi_requests/__init__.py
+++ b/jsonapi_requests/__init__.py
@@ -2,4 +2,4 @@ from .base import Api
 from .data import JsonApiObject
 from . import orm
 
-__all__ = [Api, JsonApiObject, orm]
+__all__ = ['Api', 'JsonApiObject', 'orm']

--- a/jsonapi_requests/orm/__init__.py
+++ b/jsonapi_requests/orm/__init__.py
@@ -3,4 +3,4 @@ from .api_model import ApiModel
 from .fields import AttributeField
 from .fields import RelationField
 
-__all__ = [OrmApi, ApiModel, AttributeField, RelationField]
+__all__ = ['OrmApi', 'ApiModel', 'AttributeField', 'RelationField']


### PR DESCRIPTION
The `__all__` variable in `__init__.py` files [should be a list of strings, not types](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package):

```
Python 3.7.4 (default, Aug 30 2019, 13:30:55) 
[GCC 5.4.0 20160609] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from jsonapi_requests import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<frozen importlib._bootstrap>", line 1031, in _handle_fromlist
  File "<frozen importlib._bootstrap>", line 1026, in _handle_fromlist
TypeError: Item in jsonapi_requests.__all__ must be str, not type
>>> 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/jsonapi-requests/49)
<!-- Reviewable:end -->
