### PR TITLE
Fix use of deprecated tenacity call api

### DIFF
--- a/jsonapi_requests/request_factory.py
+++ b/jsonapi_requests/request_factory.py
@@ -31,7 +31,7 @@ class ApiRequestFactory:
         if object is not None:
             assert 'json' not in kwargs
             kwargs['json'] = {'data': object.as_data()}
-        return self.retrying.call(self._request, url, method, **kwargs)
+        return self.retrying.__call__(self._request, url, method, **kwargs)
 
     @property
     def retrying(self):

--- a/jsonapi_requests/request_factory.py
+++ b/jsonapi_requests/request_factory.py
@@ -31,7 +31,7 @@ class ApiRequestFactory:
         if object is not None:
             assert 'json' not in kwargs
             kwargs['json'] = {'data': object.as_data()}
-        return self.retrying.__call__(self._request, url, method, **kwargs)
+        return self.retrying(self._request, url, method, **kwargs)
 
     @property
     def retrying(self):


### PR DESCRIPTION
I think it fixes #53 
But since no tests were broken before this I can't really be sure.

Python is not my most used language, so please sanity check my assumptions, somehow?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/socialwifi/jsonapi-requests/54)
<!-- Reviewable:end -->
